### PR TITLE
add zindex to github icon to make it clickable on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
             <div class="flex flex-row justify-center items-center translate-x-[5%]">Made with <img class="w-4 h-4 mx-2"
                     src="img/heart.svg" alt="love"> by <img class="ml-2 h-4" src="img/logo_tilleuls.svg" alt="Les-Tilleuls.coop"></div>
         </a>
-        <a title="FrankenPHP on Github" aria-label="FrankenPHP on Github" href="https://github.com/dunglas/frankenphp" target="_blank" rel="noreferrer noopener" class="flex flex-row text-white absolute top-4 right-4 text-sm items-center"><img src="img/github.svg" class="w-6 h-6" alt="GitHub"></a>
+        <a title="FrankenPHP on Github" aria-label="FrankenPHP on Github" href="https://github.com/dunglas/frankenphp" target="_blank" rel="noreferrer noopener" class="flex flex-row text-white absolute top-4 right-4 z-20 text-sm items-center"><img src="img/github.svg" class="w-6 h-6" alt="GitHub"></a>
         <div class="container min-h-screen flex flex-col items-center justify-between relative z-10 pt-24 | md:pt-0 md:landscape:flex-row ">
 
             <div class="flex-1 flex justify-center items-center flex-col py-4 | sm:py-12 | md:items-start md:my-0 md:landscape:w-1/2 |">


### PR DESCRIPTION
Hi there!
This tiny change should fix the the github icon link in the top right corner.
It wasn't clickable before.
_An_