### PR TITLE
Fix typo in getting starter docker command

### DIFF
--- a/data/home/getting_started.yaml
+++ b/data/home/getting_started.yaml
@@ -4,8 +4,8 @@ overtitle: "One command to run them all"
 docker: |
   ```bash
   # Docker
-  docker -v $PWD:/app/public -p 443:443 \
-    run dunglas/frankenphp
+  docker run -v $PWD:/app/public -p 443:443 \
+    dunglas/frankenphp
   ```
 standard: |
   ```bash


### PR DESCRIPTION
I think this is a typo?  The original command doesn't work on "Docker version 24.0.6" on my Mac.

Also, should `$PWD:/app/public` be `$PWD:/app`?  I think it needs to be for my Symfony app otherwise most of the files are missing, but perhaps that's too project specific?