### PR TITLE
docs: promote FrankenWP instead of frankenphp-wordpress

### DIFF
--- a/data/cn/home/technos.yaml
+++ b/data/cn/home/technos.yaml
@@ -7,8 +7,8 @@ content:
     title: "Sulu"
     url: https://sulu.io/blog/running-sulu-with-frankenphp
   - image: "wordpress.png"
-    title: "Wordpress"
-    url: https://github.com/dunglas/frankenphp-wordpress
+    title: "WordPress"
+    url: https://github.com/StephenMiracle/frankenwp
   - image: "laravel.png"
     title: "Laravel"
     url: /cn/docs/laravel/

--- a/data/en/home/technos.yaml
+++ b/data/en/home/technos.yaml
@@ -7,8 +7,8 @@ content:
     title: "Sulu"
     url: https://sulu.io/blog/running-sulu-with-frankenphp
   - image: "wordpress.png"
-    title: "Wordpress"
-    url: https://github.com/dunglas/frankenphp-wordpress
+    title: "WordPress"
+    url: https://github.com/StephenMiracle/frankenwp
   - image: "laravel.png"
     title: "Laravel"
     url: /docs/laravel/

--- a/data/fr/home/technos.yaml
+++ b/data/fr/home/technos.yaml
@@ -7,8 +7,8 @@ content:
     title: "Sulu"
     url: https://sulu.io/blog/running-sulu-with-frankenphp
   - image: "wordpress.png"
-    title: "Wordpress"
-    url: https://github.com/dunglas/frankenphp-wordpress
+    title: "WordPress"
+    url: https://github.com/StephenMiracle/frankenwp
   - image: "laravel.png"
     title: "Laravel"
     url: /fr/docs/laravel/

--- a/data/tr/home/technos.yaml
+++ b/data/tr/home/technos.yaml
@@ -7,8 +7,8 @@ content:
     title: "Sulu"
     url: https://sulu.io/blog/running-sulu-with-frankenphp
   - image: "wordpress.png"
-    title: "Wordpress"
-    url: https://github.com/dunglas/frankenphp-wordpress
+    title: "WordPress"
+    url: https://github.com/StephenMiracle/frankenwp
   - image: "laravel.png"
     title: "Laravel"
     url: /docs/laravel/


### PR DESCRIPTION
See https://github.com/dunglas/frankenphp/pull/785.

cc @StephenMiracle