### PR TITLE
Fix link to edit page while on non "en" website

### DIFF
--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -15,7 +15,11 @@
           {{ else if (eq $lastUrlElement "contributing") }}
             href="https://github.com/dunglas/frankenphp/blob/main/CONTRIBUTING.md"
           {{ else }}
-            href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ $lastUrlElement }}.md"
+              {{ if (eq .Lang "en" )}}
+                href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ $lastUrlElement }}.md"
+              {{ else }}
+                href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ .Lang }}/{{ $lastUrlElement }}.md"
+              {{ end }}
           {{ end }}
         >
           <svg

--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -15,11 +15,11 @@
           {{ else if (eq $lastUrlElement "contributing") }}
             href="https://github.com/dunglas/frankenphp/blob/main/CONTRIBUTING.md"
           {{ else }}
-              {{ if (eq .Lang "en" )}}
-                href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ $lastUrlElement }}.md"
-              {{ else }}
-                href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ .Lang }}/{{ $lastUrlElement }}.md"
-              {{ end }}
+            {{ if (eq .Lang "en" )}}
+              href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ $lastUrlElement }}.md"
+            {{ else }}
+              href="https://github.com/dunglas/frankenphp/blob/main/docs/{{ .Lang }}/{{ $lastUrlElement }}.md"
+            {{ end }}
           {{ end }}
         >
           <svg


### PR DESCRIPTION
The link to "edit this page" always goes to the english section.

Example on this page: https://frankenphp.dev/fr/docs/config/

The link goes to
 
> https://github.com/dunglas/frankenphp/blob/main/docs/config.md 

while it should go to 

> https://github.com/dunglas/frankenphp/blob/main/docs/fr/config.md


Did not test it locally, but I hope this will fix the problem or the CI will tell me what's wrong.