### PR TITLE
fix for transition on Safari

### DIFF
--- a/layouts/partials/home/getting_started.html
+++ b/layouts/partials/home/getting_started.html
@@ -1,7 +1,7 @@
 {{ with index .Site.Data .Site.Language.Lang "home" "getting_started" }}
   <section
     id="getting-started"
-    class="bg-white py-12 md:py-24 relative before:clip-path-inclinated before:bg-white before:w-full before:h-48 before:absolute before:bottom-full before:left-0 translate-y-[0.5px]"
+    class="bg-white py-12 md:py-24 relative before:clip-path-inclinated before:bg-white before:w-full before:h-48 before:absolute before:bottom-full before:left-0"
   >
     <div
       class="container relative flex flex-col-reverse lg:flex-row justify-center gap-12 lg:gap-24"


### PR DESCRIPTION
This fixes an issue with transitions on Safari for iOS and macOS.
See video attachments below:

# The bug ⬇️

https://github.com/user-attachments/assets/813435c8-23a0-4ea1-8495-2bf0feff9566

# The fix ⬇️

https://github.com/user-attachments/assets/043dbe4d-a09c-4015-af2b-4c61771c8cd8

