### PR TITLE
feat: improve SEO and usability

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,30 +4,40 @@
     <meta charset="UTF-8" />
     <meta name="go-import" content="frankenphp.dev git https://github.com/php/frankenphp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="{{ i18n "metadescription" }}" />
+    {{- $pageTitle := i18n "metatitle" }}
+    {{- with .File }}
+      {{- $navData := index $.Site.Data $.Lang }}
+      {{- with $navData }}
+        {{- $basename := $.File.ContentBaseName }}
+        {{- range .nav.links }}
+          {{- if hasSuffix .url (printf "/docs/%s/" $basename) }}{{ $pageTitle = printf "%s - FrankenPHP" .title }}{{ end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $description := "" }}
+    {{- with .Description }}{{ $description = . }}
+    {{- else }}{{ if .IsHome }}{{ $description = i18n "metadescription" }}{{ end }}
+    {{- end }}
+    {{- with $description }}<meta name="description" content="{{ . }}" />{{ end }}
+    <link rel="canonical" href="{{ .Permalink }}" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@dunglas" />
-    <meta name="twitter:creator" content="@dunglas" />
     <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
     {{ range .Translations }}
       <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
     {{ end }}
-    <meta
-      name="twitter:title"
-      content="{{ i18n "metatitle" }}"
-    />
-    <meta
-      name="twitter:description"
-      content="{{ i18n "metadescription" }}"
-    />
-    <meta name="twitter:image" content="https://frankenphp.dev/card.png" />
-    <meta name="og:image" content="https://frankenphp.dev/card.png" />
-    <meta name="og:title" content="{{ i18n "metatitle" }}" />
-    <meta
-      name="og:description"
-      content="{{ i18n "metadescription" }}"
-    />
-    <title>{{ i18n "metatitle" }}</title>
+    {{- $defaultPermalink := .Permalink }}
+    {{- if ne .Lang "en" }}
+      {{- range .Translations }}{{ if eq .Lang "en" }}{{ $defaultPermalink = .Permalink }}{{ end }}{{ end }}
+    {{- end }}
+    <link rel="alternate" hreflang="x-default" href="{{ $defaultPermalink }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ .Permalink }}" />
+    <meta property="og:image" content="https://frankenphp.dev/card.png" />
+    <meta property="og:title" content="{{ $pageTitle }}" />
+    {{- with $description }}
+    <meta property="og:description" content="{{ . }}" />
+    {{- end }}
+    <title>{{ $pageTitle }}</title>
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />


### PR DESCRIPTION
  - **Per-page `<title>`**: Doc pages now use the short navigation title from `nav.yaml` (e.g., "Docker images - FrankenPHP") instead of the same generic title on every page
  - **Canonical URL**: Added `<link rel="canonical">` to all pages
  - **`hreflang="x-default"`**: Added to point search engines to the English version as the default language
  - **Fix Open Graph tags**: Changed `name="og:*"` to `property="og:*"` (per the OG spec), added missing `og:type` and `og:url`
  - **Remove meta description on doc pages**: Only the homepage keeps its curated description; doc pages omit it to let search engines generate better snippets from the content
  - **Remove obsolete Twitter meta tags**: X/Twitter now uses OG tags; removed `twitter:site`, `twitter:creator`, `twitter:title`, `twitter:description`, and `twitter:image`, keeping only `twitter:card` which has no OG equivalent