### PR TITLE
Adopt upstream SEO frontmatter, llms.txt, and fix Hugo deprecations

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.157.0
+      HUGO_VERSION: 0.161.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ content/**/docs/
 data/**/nav.yaml
 static/install.sh
 static/install.ps1
+static/llms.txt
 public

--- a/clone-documentation.php
+++ b/clone-documentation.php
@@ -98,12 +98,27 @@ function fixLinks($content, $lang = "en")
     return $content;
 }
 
-// Function to add layout and title on docs pages
+// Function to add layout and title on docs pages.
+// Detects existing upstream YAML frontmatter (title, description) so the
+// SEO-tuned values added in php/frankenphp#2394 are preserved.
 function addFrontmatter($content)
 {
-    $title = "FrankenPHP";
-    $navtitle = "";
+    $upstreamTitle = "";
+    $upstreamDescription = "";
 
+    if (preg_match('/^---\s*\R(.*?)\R---\s*\R(.*)$/s', $content, $m)) {
+        $upstream = $m[1];
+        $content = $m[2];
+        if (preg_match('/^title:\s*(.+?)\s*$/m', $upstream, $tm)) {
+            $upstreamTitle = trim($tm[1], "\"'");
+        }
+        if (preg_match('/^description:\s*(.+?)\s*$/m', $upstream, $dm)) {
+            $upstreamDescription = trim($dm[1], "\"'");
+        }
+    }
+
+    $navtitle = "";
+    $title = "FrankenPHP";
     if (preg_match('/#\s+([^\n]+)/', $content, $matches)) {
         $navtitle = $matches[1];
         $title = stripos($navtitle, 'frankenphp') === 0
@@ -111,7 +126,18 @@ function addFrontmatter($content)
             : "FrankenPHP | $navtitle";
     }
 
-    return "---\nlayout: docs\ntitle: \"$title\"\nnav: \"$navtitle\"\n---\n$content";
+    $escape = fn ($s) => str_replace('"', '\\"', $s);
+
+    $frontmatter = "---\nlayout: docs\ntitle: \"" . $escape($title) . "\"\nnav: \"" . $escape($navtitle) . "\"\n";
+    if ($upstreamTitle !== "") {
+        $frontmatter .= "seotitle: \"" . $escape($upstreamTitle) . "\"\n";
+    }
+    if ($upstreamDescription !== "") {
+        $frontmatter .= "description: \"" . $escape($upstreamDescription) . "\"\n";
+    }
+    $frontmatter .= "---\n";
+
+    return $frontmatter . $content;
 }
 
 function generateLangDocumentation($repoURL, $lang = "en")
@@ -184,6 +210,16 @@ function generateLangDocumentation($repoURL, $lang = "en")
         if (is_file($INSTALLPS1)) {
             if (!copy($INSTALLPS1, $DEST)) {
                 echo "Error when copying install.ps1\n";
+                return;
+            }
+        }
+
+        $LLMSTXT = "$TEMP_DIR/llms.txt";
+        $DEST = __DIR__ . "/static/llms.txt";
+
+        if (is_file($LLMSTXT)) {
+            if (!copy($LLMSTXT, $DEST)) {
+                echo "Error when copying llms.txt\n";
                 return;
             }
         }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,5 @@
 
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'FrankenPHP: the modern PHP app server'
 markup:
   goldmark:
@@ -13,9 +13,9 @@ defaultContentLanguage: en
 languages:
   en:
     disabled: false
-    languageCode: "en"
+    locale: "en"
     languageDirection: ""
-    languageName: "English"
+    label: "English"
     contentDir: content/en
     title: ""
     weight: 1
@@ -32,9 +32,9 @@ languages:
         weight: 5
   zh:
     disabled: false
-    languageCode: "zh"
+    locale: "zh"
     languageDirection: ""
-    languageName: "Chinese"
+    label: "Chinese"
     contentDir: content/zh
     title: ""
     weight: 2
@@ -53,9 +53,9 @@ languages:
         weight: 5
   ja:
     disabled: false
-    languageCode: "jp"
+    locale: "jp"
     languageDirection: ""
-    languageName: "Japanese"
+    label: "Japanese"
     contentDir: content/ja
     title: ""
     weight: 2
@@ -74,9 +74,9 @@ languages:
         weight: 5
   es:
     disabled: false
-    languageCode: "es"
+    locale: "es"
     languageDirection: ""
-    languageName: "Spanish"
+    label: "Spanish"
     contentDir: content/es
     title: ""
     weight: 4
@@ -93,9 +93,9 @@ languages:
         weight: 5
   fr:
     disabled: false
-    languageCode: "fr"
+    locale: "fr"
     languageDirection: ""
-    languageName: "French"
+    label: "French"
     contentDir: content/fr
     title: ""
     weight: 3
@@ -112,9 +112,9 @@ languages:
           target: _blank
   tr:
     disabled: false
-    languageCode: "tr"
+    locale: "tr"
     languageDirection: ""
-    languageName: "Turkish"
+    label: "Turkish"
     contentDir: content/tr
     title: ""
     weight: 6
@@ -131,9 +131,9 @@ languages:
           target: _blank
   ru:
     disabled: false
-    languageCode: "ru"
+    locale: "ru"
     languageDirection: ""
-    languageName: "Russian"
+    label: "Russian"
     contentDir: content/ru
     title: ""
     weight: 6
@@ -150,9 +150,9 @@ languages:
           target: _blank
   pt-br:
     disabled: false
-    languageCode: "pt-br"
+    locale: "pt-br"
     languageDirection: ""
-    languageName: "Brazilian Portuguese"
+    label: "Brazilian Portuguese"
     contentDir: content/pt-br
     title: ""
     weight: 2

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -53,7 +53,7 @@ languages:
         weight: 5
   ja:
     disabled: false
-    locale: "jp"
+    locale: "ja"
     languageDirection: ""
     label: "Japanese"
     contentDir: content/ja

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {{- $pageTitle := i18n "metatitle" }}
     {{- with .File }}
-      {{- $navData := index $.Site.Data $.Lang }}
+      {{- $navData := index hugo.Data $.Lang }}
       {{- with $navData }}
         {{- $basename := $.File.ContentBaseName }}
         {{- range .nav.links }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,7 @@
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- with .Params.seotitle }}{{ $pageTitle = . }}{{ end }}
     {{- $description := "" }}
     {{- with .Description }}{{ $description = . }}
     {{- else }}{{ if .IsHome }}{{ $description = i18n "metadescription" }}{{ end }}

--- a/layouts/_default/help.html
+++ b/layouts/_default/help.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $lang := .Lang }}
-  {{ with index .Site.Data .Site.Language.Lang "help" }}
+  {{ with index hugo.Data .Site.Language.Lang "help" }}
     <div
       class="mx-auto overflow-x-clip pb-40 {{ if eq $lang "en" }}
         pt-16

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -81,7 +81,7 @@
       </svg>
     </label>
 
-    {{ with index .Site.Data .Site.Language.Lang "nav" }}
+    {{ with index hugo.Data .Site.Language.Lang "nav" }}
       <ul class="flex flex-col gap-2">
         {{ with .links }}
           {{ range . }}

--- a/layouts/partials/home/features.html
+++ b/layouts/partials/home/features.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "features" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "features" }}
   <div class="container text-center relative max-w-6xl px-12">
     <div
       id="lightning"

--- a/layouts/partials/home/getting_started.html
+++ b/layouts/partials/home/getting_started.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "getting_started" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "getting_started" }}
   <script>
     function openCode(codeTab) {
       var i;

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "hero" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "hero" }}
   <section id="hero" class="bg-purple-dark relative overflow-x-hidden">
     <div
       class="container min-h-screen flex flex-col items-center justify-between relative z-10 pt-24 | md:pt-0 md:landscape:flex-row "

--- a/layouts/partials/home/install_code.html
+++ b/layouts/partials/home/install_code.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "install_code" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "install_code" }}
   <section id="code" class="bg-white py-12 md:py-24 relative">
     <div
       id="lightning2"

--- a/layouts/partials/home/modern.html
+++ b/layouts/partials/home/modern.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "modern" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "modern" }}
   <section id="modern" class="py-12 lg:py-24 px-4">
     <div
       class="container relative max-w-6xl bg-gray-100 py-12 rounded-[50px] px-8 lg:px-14 overflow-hidden"

--- a/layouts/partials/home/technos.html
+++ b/layouts/partials/home/technos.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "technos" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "technos" }}
   <section id="technos" class="w-full relative">
     <div
       class="absolute z-20 h-full w-[10vw] bg-gradient-to-r from-white to-transparent left-0 top-0"

--- a/layouts/partials/home/worker.html
+++ b/layouts/partials/home/worker.html
@@ -1,4 +1,4 @@
-{{ with index .Site.Data .Site.Language.Lang "home" "worker" }}
+{{ with index hugo.Data .Site.Language.Lang "home" "worker" }}
   <section id="worker" class="py-12 md:py-24">
     <div class="container relative ">
       <div


### PR DESCRIPTION
## Summary

- Sync the docs pipeline with https://github.com/php/frankenphp/pull/2394: `clone-documentation.php` now parses the upstream YAML frontmatter (`title`, `description`) and emits them as Hugo `seotitle` / `description` params; `baseof.html` uses `seotitle` for `<title>`, `og:title`, and `twitter:title` when present. Translations and CONTRIBUTING/README fall back to the existing `nav`-derived title.
- Copy upstream `llms.txt` into `static/llms.txt` so it is served at https://frankenphp.dev/llms.txt, matching the canonical paths advertised in the file. Added to `.gitignore` next to `install.sh` / `install.ps1`.
- Replace Hugo config keys deprecated in v0.158 (`languageCode` → `locale`, `languageName` → `label`) and switch every template from `.Site.Data` to `hugo.Data` (deprecated in v0.156). Build is now warning-free.